### PR TITLE
Declare beta EOL

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "end-of-life": "The flathub beta repository has been used for publishing the Betterbird 140 preview. It no longer receives any updates. Please migrate to Betterbird from the flathub stable repository which has been updated to version 140."
+}


### PR DESCRIPTION
Adds a notice to the flathub beta repository
indicating it's no longer receiving updates and
recommending migration to the stable repository.
