### PR TITLE
Declare beta branch end-of-life

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
+  "end-of-life": "The flathub beta repository has been used for publishing the Betterbird 153 preview. It no longer receives any updates. Please migrate to Betterbird from the flathub stable repository which has been updated to version 153.",
   "disable-external-data-checker": true
 }


### PR DESCRIPTION
The flathub beta repository was used for publishing the Betterbird 153 preview. It no longer receives updates. Users should migrate to Betterbird from the flathub stable repository, which will be updated to version 153.